### PR TITLE
[Feature] add-entity-exercise-log

### DIFF
--- a/src/main/java/com/example/healthcare/exercise/domain/Exercise.java
+++ b/src/main/java/com/example/healthcare/exercise/domain/Exercise.java
@@ -23,6 +23,9 @@ public class Exercise extends Base {
   @Column(name = "name", nullable = false, length = 191)
   private String name;
 
+  @Column(name = "description", length = 3000)
+  private String description;
+
   @Enumerated(value = EnumType.STRING)
   @Column(name = "exercise_body_type", nullable = false, length = 191)
   private ExerciseBodyType bodyType;

--- a/src/main/java/com/example/healthcare/exercise/domain/UserExerciseLog.java
+++ b/src/main/java/com/example/healthcare/exercise/domain/UserExerciseLog.java
@@ -1,0 +1,46 @@
+package com.example.healthcare.exercise.domain;
+
+import com.example.healthcare.account.domain.User;
+import com.example.healthcare.common.domain.Base;
+import com.example.healthcare.exercise.domain.code.ExerciseTimeType;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@DynamicUpdate
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_exercise_log",
+  uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"exercise_date", "exercise_time_type", "user_id"})
+  }
+)
+public class UserExerciseLog extends Base {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  @Column(name = "user_exercise_log_id")
+  private Long id;
+
+  private LocalDateTime startDateTime;
+  private LocalDateTime endDateTime;
+
+  @Column(name = "exercise_date", nullable = false)
+  private LocalDate exerciseDate;
+  @Enumerated(value = EnumType.STRING)
+  @Column(name = "exercise_time_type", length = 191)
+  private ExerciseTimeType exerciseTimeType;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "user_id")
+  @JsonBackReference
+  private User user;
+
+}

--- a/src/main/java/com/example/healthcare/exercise/domain/UserExerciseRoutine.java
+++ b/src/main/java/com/example/healthcare/exercise/domain/UserExerciseRoutine.java
@@ -1,7 +1,7 @@
 package com.example.healthcare.exercise.domain;
 
+import com.example.healthcare.account.domain.User;
 import com.example.healthcare.common.domain.Base;
-import com.example.healthcare.exercise.domain.code.ExerciseType;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -13,20 +13,21 @@ import org.hibernate.annotations.DynamicUpdate;
 @DynamicUpdate
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ExerciseTypeRelation extends Base {
+public class UserExerciseRoutine extends Base {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
-  @Column(name = "exercise_type_relation_id")
+  @Column(name = "user_exercise_routine_id")
   private Long id;
 
-  @Enumerated(value = EnumType.STRING)
-  @Column(name = "exercise_type", length = 191)
-  private ExerciseType exerciseType;
+  private Long restTime;
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_exercise_log_id", nullable = false, referencedColumnName = "user_exercise_log_id")
+  @JsonBackReference
+  private UserExerciseLog userExerciseLog;
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "exercise_id", nullable = false, referencedColumnName = "exercise_id")
   @JsonBackReference
   private Exercise exercise;
-
 }

--- a/src/main/java/com/example/healthcare/exercise/domain/UserExerciseSet.java
+++ b/src/main/java/com/example/healthcare/exercise/domain/UserExerciseSet.java
@@ -1,0 +1,45 @@
+package com.example.healthcare.exercise.domain;
+
+import com.example.healthcare.account.domain.User;
+import com.example.healthcare.exercise.domain.code.ExerciseSetType;
+import com.example.healthcare.exercise.domain.code.ExerciseTimeType;
+import com.example.healthcare.exercise.domain.code.WeightUnitType;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@DynamicUpdate
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserExerciseSet {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  @Column(name = "user_exercise_set_id")
+  private Long id;
+
+  @Column(name = "setNumber", nullable = false)
+  private Long setNumber;
+  @Enumerated(value = EnumType.STRING)
+  @Column(name = "exercise_set_type", length = 191)
+  private ExerciseSetType exerciseSetType;
+
+  @Enumerated(value = EnumType.STRING)
+  @Column(name = "weight_unit_type", length = 191)
+  private WeightUnitType weightUnitType;
+  private Long wight;
+  private Integer reps;
+  private Long time;
+
+  private boolean complete;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_exercise_routine_id", nullable = false, referencedColumnName = "user_exercise_routine_id")
+  @JsonBackReference
+  private UserExerciseRoutine userExerciseRoutine;
+
+}

--- a/src/main/java/com/example/healthcare/exercise/domain/code/ExerciseSetType.java
+++ b/src/main/java/com/example/healthcare/exercise/domain/code/ExerciseSetType.java
@@ -1,0 +1,7 @@
+package com.example.healthcare.exercise.domain.code;
+
+public enum ExerciseSetType {
+
+  DEFAULT, WARMUP, DROP, FAIL
+
+}

--- a/src/main/java/com/example/healthcare/exercise/domain/code/ExerciseTimeType.java
+++ b/src/main/java/com/example/healthcare/exercise/domain/code/ExerciseTimeType.java
@@ -1,0 +1,7 @@
+package com.example.healthcare.exercise.domain.code;
+
+public enum ExerciseTimeType {
+
+  DAY, EVENING, NIGHT
+
+}

--- a/src/main/java/com/example/healthcare/exercise/domain/code/WeightUnitType.java
+++ b/src/main/java/com/example/healthcare/exercise/domain/code/WeightUnitType.java
@@ -1,0 +1,22 @@
+package com.example.healthcare.exercise.domain.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum WeightUnitType {
+
+  KILOGRAM("kg"),
+  POUND("lbs");
+
+  private final String unit;
+
+  public static long kgToLbs(long kg) {
+    return (long) (kg * 2.20462);
+  }
+
+  public static long lbsToKg(long lbs) {
+    return (long) (lbs * 0.45359237);
+  }
+}


### PR DESCRIPTION
🔎 **What is this PR?**

사용자 운동 기록 관리를 위한 엔티티 추가

📝 **Changes**

```
사용자 -> {?}요일 오전 운동 기록 -> 종목1, 종목2, 종목3, ... -> 종목별 세트번호, 세트종류, 무게, 시간, 횟수 기록
      -> {?}요일 오후 운둥 기록 -> 종목1, 종목2, 종목3, ...
      -> {?}요일 아갼 운동 기록 -> 종목1, 종목2, 종목3, ...
```

✅ **Test Checklist**

1. 사용자는 하루 중 오전, 오후, 야간 운동을 선택하여 기록할 수 있음
2. 사용자의 오전, 오후 또는 야간 운동 루틴에는 여러 종목의 운동을 선택할 수 있음
3. 하나의 운동 종목에는 여러 세트를 설정할 수 있음